### PR TITLE
Abertura do endpoint departamento

### DIFF
--- a/src/main/java/com/io/Suport4All/infra/security/SecurityConfig.java
+++ b/src/main/java/com/io/Suport4All/infra/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 	                        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
 	                        .requestMatchers(HttpMethod.GET, "/swagger-ui.html").permitAll()
 	                        .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
+	                        .requestMatchers(HttpMethod.GET, "/departamento").permitAll()
 	                        .requestMatchers(HttpMethod.GET,"/usuarios/all").hasAuthority("ADMIN")
 	                        .anyRequest().authenticated()
 	                )


### PR DESCRIPTION
Por questões de necessidade, foi preciso abrir o Endpoint de departamento para qualquer um acessar. Isso se deve ao fato de qualquer pessoa poder criar um usuário na aplicação.

